### PR TITLE
Remove __del__ method

### DIFF
--- a/iceutils/stack.py
+++ b/iceutils/stack.py
@@ -48,12 +48,6 @@ class Stack:
 
         return
 
-#     def __del__(self):
-#         """
-#         Close HDF5 dataset.
-#         """
-#         if self.fid is not None:
-#             self.fid.close()
 
     def initialize(self, tdec, raster_info, data=True, weights=False, chunks=(1, 128, 128)):
         """

--- a/iceutils/stack.py
+++ b/iceutils/stack.py
@@ -48,12 +48,12 @@ class Stack:
 
         return
 
-    def __del__(self):
-        """
-        Close HDF5 dataset.
-        """
-        if self.fid is not None:
-            self.fid.close()
+#     def __del__(self):
+#         """
+#         Close HDF5 dataset.
+#         """
+#         if self.fid is not None:
+#             self.fid.close()
 
     def initialize(self, tdec, raster_info, data=True, weights=False, chunks=(1, 128, 128)):
         """


### PR DESCRIPTION
Destructor `Stack.__del__` was crashing a test script.  We found that the method was unnecessary, and that removing it allowed test scripts to run without error.

Merging this PR should close #4 